### PR TITLE
Fix filesystem problem in courier-imap filesystem

### DIFF
--- a/courier-imap/Dockerfile
+++ b/courier-imap/Dockerfile
@@ -1,11 +1,9 @@
 #
 # Dockerfile for a IMAP server
 #
-FROM debian:jessie
+FROM ubuntu:trusty
 
 MAINTAINER Vampouille "julien.acroute@camptocamp.com"
-
-ENV DEBIAN_FRONTEND noninterative
 
 # Avoid ERROR: invoke-rc.d: policy-rc.d denied execution of start. 
 RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d

--- a/smtp-sink/Dockerfile
+++ b/smtp-sink/Dockerfile
@@ -3,7 +3,7 @@
 #
 FROM ubuntu:trusty
 
--MAINTAINER Vampouille "julien.acroute@camptocamp.com"
+MAINTAINER Vampouille "julien.acroute@camptocamp.com"
 
 RUN apt-get update && \
     apt-get install -y postfix courier-base && \

--- a/smtp-sink/Dockerfile
+++ b/smtp-sink/Dockerfile
@@ -1,11 +1,9 @@
 #
 # Dockerfile for a catch-all SMTP server
 #
-FROM debian:jessie
+FROM ubuntu:trusty
 
-MAINTAINER Vampouille "julien.acroute@camptocamp.com"
-
-ENV DEBIAN_FRONTEND noninterative
+-MAINTAINER Vampouille "julien.acroute@camptocamp.com"
 
 RUN apt-get update && \
     apt-get install -y postfix courier-base && \


### PR DESCRIPTION
 https://tvi.al/how-to-fix-the-gamin-fam-issue/

When connecting via imap an error occurs 

* OK [ALERT] Filesystem notification initialization error -- contact your mail administrator (check for configuration errors with the FAM/Gamin library)

Fix is to use a distro that has both courier and gamin.

